### PR TITLE
Kill two birds with one stone(#2 and #8)

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -100,6 +100,7 @@
                                 </li>
                             </ul>
                         </li>
+                        <!--
                         <li>
                             <a href="/elections">
                                 <span class="label-nav">
@@ -110,6 +111,7 @@
                                 </span>
                             </a>
                         </li>
+                        -->
                     </ul>
 
                 </nav>


### PR DESCRIPTION
Found that hiding the "Elections" link in the navigation menu makes the menu smaller so as to avoid the stacking or crowding of buttons on smaller screens.
